### PR TITLE
Updated Function JoinString() to add mandatory parenthesis support on MS Access JOIN Query

### DIFF
--- a/src/ClassModules/SQLSelect.cls
+++ b/src/ClassModules/SQLSelect.cls
@@ -217,6 +217,7 @@ End Function
 
 Private Function JoinString()
     Dim R As Long
+    Dim I As Long
     Dim Lines() As String
     Dim Line As String
     Dim LineArray As Variant
@@ -236,7 +237,19 @@ Private Function JoinString()
         If LineArray(3) <> "" Then
             Line = Line & " ON " & LineArray(3)
         End If
-        Lines(R) = Line
+       'Add inicial open parenthesis as needed join
+        If R = 0 And UBound(aJoin) > 1 Then
+            For I = 2 To UBound(aJoin)
+                Line = " ( " & Line
+            Next I
+            Lines(R) = Line
+        'Add close parenthesis for join
+        ElseIf R > 0 And R < UBound(aJoin) And UBound(aJoin) > 1 Then
+            Lines(R) = Line & " ) "
+        Else
+            'Normal output
+            Lines(R) = Line
+        End If
     Next R
     JoinString = Join(Lines, " ")
 End Function


### PR DESCRIPTION
Updated Function JoinString() to add mandatory parenthesis support on MS Access JOIN Query
New Function Code:

Private Function JoinString()
    Dim R As Long
    Dim I As Long
    Dim Lines() As String
    Dim Line As String
    Dim LineArray As Variant
    ReDim Lines(0 To UBound(aJoin))
    For R = 0 To UBound(aJoin)
        LineArray = aJoin(R)
        Line = ""
        If LineArray(0) <> "" Then
            Line = LineArray(0) & " JOIN "
        ElseIf R > 0 Then
            Lines(R - 1) = Lines(R - 1) & ","
        End If
        Line = Line & LineArray(1)
        If LineArray(2) <> "" Then
            Line = Line & " " & LineArray(2)
        End If
        If LineArray(3) <> "" Then
            Line = Line & " ON " & LineArray(3)
        End If
       'Add inicial open parenthesis as needed join
        If R = 0 And UBound(aJoin) > 1 Then
            For I = 2 To UBound(aJoin)
                Line = " ( " & Line
            Next I
            Lines(R) = Line
        'Add close parenthesis for join
        ElseIf R > 0 And R < UBound(aJoin) And UBound(aJoin) > 1 Then
            Lines(R) = Line & " ) "
        Else
            'Normal output
            Lines(R) = Line
        End If
    Next R
    JoinString = Join(Lines, " ")
End Function
