### PR TITLE
Don't perform any EOL conversions on VBA files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,10 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
 
-# Declare files that will always have CRLF line endings on checkout.
-*.cls text eol=crlf
-*.frm text eol=crlf
-*.bas text eol=crlf
+# Don't perform any EOL conversions on VBA files to preserve CRLF from the VBE.
+*.cls -text
+*.frm -text
+*.bas -text
 
 # Denote all files that are truly binary and should not be modified.
 *.frx binary


### PR DESCRIPTION
As mentioned in [this comment](https://github.com/Beakerboy/VBA-SQL-Library/issues/56#issuecomment-1844498212), the current `.gitattributes` configurations makes it so that anyone who clones the project will see that it has pending changes. That's because Git will normalize the CRLF inside the working tree to LF in the Index.

These new configurations will ensure that VBA code files keep their CRLF line endings in both the working tree and the index[^1].

See also: [Does the use of -text affect how Git performs diffs?](https://github.com/DecimalTurn/VBA-on-GitHub#does-the-use-of--text-affect-how-git-performs-diffs)

Closes #56

[^1]: This remains true as long as VBA files are produced by exporting them from the VBE. If someone create a new VBA file from an IDE configured to use LF, these line endings won't be converted to CRLF. This is quite unlikely unless you expect a lot of contributors to work with a UNIX/Linux machine. If you want to be 100% sure no LFs are introduced by mistake, there is always this action that can be used: https://github.com/marketplace/actions/enforce-crlf.